### PR TITLE
Improve ContactForm submission gating

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -279,17 +279,25 @@ const ContactForm = () => {
           variant="contained"
           color="primary"
           size="large"
-          /* disabled={isSubmitting || !recaptchaLoaded} */
+          disabled={isSubmitting || !recaptchaLoaded}
           sx={{
             alignSelf: "center",
             padding: "0.8rem 2rem",
             mt: 3,
             width: "auto",
-            backgroundColor: "#45c07d"
+            backgroundColor: "#45c07d",
+            "&.Mui-disabled": {
+              backgroundColor: "#bdbdbd",
+              color: "#666",
+            },
           }}
           startIcon={isSubmitting ? <CircularProgress size={24} /> : null}
         >
-          {isSubmitting ? "Enviando..." : "Enviar"}
+          {isSubmitting
+            ? "Enviando..."
+            : !recaptchaLoaded
+            ? "Cargando..."
+            : "Enviar"}
         </Button>
       </Stack>
     </Box>

--- a/src/components/__tests__/ContactForm.test.jsx
+++ b/src/components/__tests__/ContactForm.test.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ContactForm from '../ContactForm';
+import axios from 'axios';
+import '@testing-library/jest-dom';
+
+jest.mock('axios', () => ({
+  post: jest.fn(),
+}));
+
+describe('ContactForm disabling', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete window.grecaptcha;
+  });
+
+  test('does not submit when reCAPTCHA is not loaded', () => {
+    render(<ContactForm />);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test('prevents additional submits while submitting', async () => {
+    window.grecaptcha = { execute: jest.fn().mockResolvedValue('token') };
+    const pending = new Promise(() => {});
+    axios.post.mockReturnValue(pending);
+
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText(/nombre/i), {
+      target: { value: 'Test' },
+    });
+    fireEvent.change(screen.getByLabelText(/correo electr\u00f3nico/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/mensaje/i), {
+      target: { value: 'Hola' },
+    });
+
+    const button = await screen.findByRole('button', { name: /enviar/i });
+    expect(button).toBeEnabled();
+
+    fireEvent.click(button);
+    await waitFor(() => expect(axios.post).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(button).toBeDisabled());
+
+    fireEvent.click(button);
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent ContactForm submission while sending or reCAPTCHA is loading
- Show disabled button styles and status text
- Test form behavior when disabled

## Testing
- `npm test -- src/components/__tests__/ContactForm.test.jsx --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a106eb2dc883248a6bbfdb53f739ef