### PR TITLE
chore: remove stray semicolon after root.render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
-
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <App/>
   </React.StrictMode>
 );
-
-;


### PR DESCRIPTION
## Summary
- remove extra semicolon after `root.render` in `src/index.js`
- ensure file ends cleanly without blank lines

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a1041e7fe48324a6b277091ccf5135